### PR TITLE
Improving json minifier

### DIFF
--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 
 mod read {
     mod byte_to_char;
+    mod internal_buffer;
     mod internal_reader;
     pub mod json_read;
 }

--- a/src/json/read/internal_buffer.rs
+++ b/src/json/read/internal_buffer.rs
@@ -1,0 +1,42 @@
+const ARRAY_DEFAULT: u8 = 0;
+
+#[derive(Debug)]
+pub struct Buffer {
+    buffer: Vec<u8>,
+    read_pos: usize,
+    buffer_size: usize,
+    data_size: usize,
+}
+
+impl Buffer {
+    pub fn new(size: usize) -> Buffer {
+        Buffer {
+            buffer: vec![ARRAY_DEFAULT; size],
+            read_pos: 0,
+            buffer_size: size,
+            data_size: 0,
+        }
+    }
+
+    pub fn as_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_mut()
+    }
+
+    pub fn update_metadata(&mut self, size: usize) {
+        self.read_pos = 0;
+        self.data_size = size;
+    }
+
+    pub fn next(&mut self) -> Option<u8> {
+        if self.read_pos >= self.data_size {
+            return None;
+        }
+        let item = self.buffer.get(self.read_pos);
+        self.read_pos += 1;
+        item.and_then(|test|Some(*test))
+    }
+
+    pub fn cont(&self) -> bool {
+        self.data_size == self.buffer_size
+    }
+}

--- a/src/json/read/json_read.rs
+++ b/src/json/read/json_read.rs
@@ -70,7 +70,7 @@ impl<P, R> Read for JsonRead<P, R>
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         let mut buf_pos: usize = 0;
 
-        if buf.len() == 0 {
+        if buf.is_empty() {
             return Ok(0);
         }
 

--- a/tests/files/test.html
+++ b/tests/files/test.html
@@ -1,9 +1,0 @@
-<html>
-<head>
-    <!--[if lte IE 8]>
-    Important comment test
-    <![endif]-->
-</head>
-<body>
-</body>
-<html>


### PR DESCRIPTION
Got another PR for #20 
This concludes the json minfier development, as its performance is now good enough IMHO

```
Command being timed: "/bin/cargo test --release --color=always --package minifier --lib json::bench_test -- --nocapture --exact"
User time (seconds): 8.74
System time (seconds): 0.13
Percent of CPU this job got: 265%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.34
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 192692
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 0
Minor (reclaiming a frame) page faults: 26041
Voluntary context switches: 222
Involuntary context switches: 785
Swaps: 0
File system inputs: 0
File system outputs: 16176
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
Exit status: 0
```