### PR TITLE
Include HTML docs in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 keywords = ["minify", "minifier", "JS", "HTML", "CSS"]
 license = "MIT"
 
+[package.metadata.docs.rs]
+features = ["html"]
+
 [badges]
 appveyor = { repository = "GuillaumeGomez/minifier-rs", service = "github" }
 travis-ci = { repository = "GuillaumeGomez/minifier-rs" }


### PR DESCRIPTION
At the moment the docs for the HTML minifier are missing [from docs.rs](https://docs.rs/minifier/0.0.19/minifier/), since those are behind a feature gate. This PR adds a bit of metadata to make sure docs.rs also builds them.