### PR TITLE
preserve whitespace after the 'and' keyword

### DIFF
--- a/src/css/css.rs
+++ b/src/css/css.rs
@@ -255,6 +255,13 @@ fn check_space_after_paren() {
 }
 
 #[test]
+fn check_space_after_and() {
+    let s = "@media only screen and (max-width : 600px) {}";
+    let expected = "@media only screen and (max-width:600px){}";
+    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+}
+
+#[test]
 fn check_whitespaces_in_calc() {
     let s = ".foo { width: calc(130px     + 10%); }";
     let expected = ".foo{width:calc(130px + 10%);}";

--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -588,7 +588,9 @@ fn clean_tokens<'a>(mut v: Vec<Token<'a>>) -> Vec<Token<'a>> {
             }
         }
         if v[i].is_useless() {
-            if is_in_calc == false &&
+            if i > 0 && v[i - 1] == Token::Other("and") {
+                // retain the space after an and
+            } else if is_in_calc == false &&
                ((i > 0 && ((v[i - 1].is_char() &&
                            v[i - 1] != Token::Char(ReservedChar::CloseParenthese)) ||
                           v[i - 1].is_a_media() ||
@@ -657,6 +659,7 @@ fn css_basic() {
                         Token::Other("screen"),
                         Token::Char(ReservedChar::Space),
                         Token::Other("and"),
+                        Token::Char(ReservedChar::Space),
                         Token::Char(ReservedChar::OpenParenthese),
                         Token::Other("max-width"),
                         Token::Char(ReservedChar::Colon),


### PR DESCRIPTION
There needs to be a space after the 'and' clause in a media query, otherwise browsers ignore the rule.

e.g. the html at https://gist.github.com/indy/c8bfac88b3be79a1fb7c48d41d280542 always renders with a yellow background regardless of screen width, only by inserting a space after the 'and' does it behave correctly.

