### PR TITLE
Use std TryFrom trait

### DIFF
--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -20,14 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use std::convert::TryFrom;
 use std::fmt;
 use std::iter::Peekable;
 use std::str::CharIndices;
-
-pub trait MyTryFrom<T>: Sized {
-    type Error;
-    fn try_from(value: T) -> Result<Self, Self::Error>;
-}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ReservedChar {
@@ -90,7 +86,7 @@ impl fmt::Display for ReservedChar {
     }
 }
 
-impl MyTryFrom<char> for ReservedChar {
+impl TryFrom<char> for ReservedChar {
     type Error = &'static str;
 
     fn try_from(value: char) -> Result<ReservedChar, Self::Error> {
@@ -160,7 +156,7 @@ impl fmt::Display for Operator {
     }
 }
 
-impl MyTryFrom<char> for Operator {
+impl TryFrom<char> for Operator {
     type Error = &'static str;
 
     fn try_from(value: char) -> Result<Operator, Self::Error> {
@@ -175,7 +171,7 @@ impl MyTryFrom<char> for Operator {
     }
 }
 
-impl MyTryFrom<ReservedChar> for Operator {
+impl TryFrom<ReservedChar> for Operator {
     type Error = &'static str;
 
     fn try_from(value: ReservedChar) -> Result<Operator, Self::Error> {
@@ -197,7 +193,7 @@ pub enum SelectorElement<'a> {
     Media(&'a str),
 }
 
-impl<'a> MyTryFrom<&'a str> for SelectorElement<'a> {
+impl<'a> TryFrom<&'a str> for SelectorElement<'a> {
     type Error = &'static str;
 
     fn try_from(value: &'a str) -> Result<SelectorElement, Self::Error> {

--- a/src/html.rs
+++ b/src/html.rs
@@ -147,7 +147,7 @@ fn unquote_attributes(source: &str) -> String {
                             } else {
                                 format!("{}", c)
                             },
-                            caps.as_str()[1..].trim_left()
+                            caps.as_str()[1..].trim_start()
                         ),
                     );
                 }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/82781, I'm trying to experiment what we might run into if `TryFrom`/`TryInto`/`FromIterator` are added to the prelude. It turns out the compiler build itself fails because method calls in minifier become ambiguous. At some point we will have `cargo fix` lints to make this easier, but for now doing this manually was easy enough.

Would be nice to get a new release out so that the compiler can pick that up.