### PR TITLE
Update regex to `1.5.5` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "GuillaumeGomez/minifier-rs" }
 html = ["regex"]
 
 [dependencies]
-regex = { version = "1.0", optional = true }
+regex = { version = "1.5.5", optional = true }
 
 [lib]
 name = "minifier"


### PR DESCRIPTION
Updates regex to `1.5.5` as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)