### PR TITLE
css: Avoid unnecessary stringification

### DIFF
--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::{fmt, io};
+
 mod token;
 
 /// Minifies a given CSS source code.
@@ -18,8 +20,22 @@ mod token;
 ///     let css_minified = minify(css);
 /// }
 /// ```
-pub fn minify<'a>(content: &'a str) -> Result<String, &'static str> {
-    token::tokenize(content).map(|t| format!("{}", t))
+pub fn minify<'a>(content: &'a str) -> Result<Minified<'a>, &'static str> {
+    token::tokenize(content).map(Minified)
+}
+
+pub struct Minified<'a>(token::Tokens<'a>);
+
+impl<'a> Minified<'a> {
+    pub fn write<W: io::Write>(self, w: W) -> io::Result<()> {
+        self.0.write(w)
+    }
+}
+
+impl<'a> fmt::Display for Minified<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 #[cfg(test)]

--- a/src/css/tests.rs
+++ b/src/css/tests.rs
@@ -152,7 +152,7 @@ a[target = "_blank"] {
 "#;
     let expected = r#"/*! Baguette! */
 .b>p+div:hover{background:#fff;}a[target="_blank"]{border:1px solid yellow;}"#;
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
@@ -189,68 +189,68 @@ h2, h3:not(.impl):not(.method):not(.type) {
                     @media (max-width:700px){.theme-picker{left:10px;top:54px;z-index:1;\
                     background-color:rgba(0,0,0,0);font:15px \"SFMono-Regular\",Consolas,\
                     \"Liberation Mono\",Menlo,Courier,monospace;}}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_calc() {
     let s = ".foo { width: calc(100% - 34px); }";
     let expected = ".foo{width:calc(100% - 34px);}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_spaces() {
     let s = ".line-numbers .line-highlighted { color: #0a042f !important; }";
     let expected = ".line-numbers .line-highlighted{color:#0a042f !important;}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_space_after_paren() {
     let s = ".docblock:not(.type-decl) a:not(.srclink) {}";
     let expected = ".docblock:not(.type-decl) a:not(.srclink){}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_space_after_and() {
     let s = "@media only screen and (max-width : 600px) {}";
     let expected = "@media only screen and (max-width:600px){}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_space_after_or_not() {
     let s = "@supports not ((text-align-last: justify) or (-moz-text-align-last: justify)) {}";
     let expected = "@supports not ((text-align-last:justify) or (-moz-text-align-last:justify)){}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_space_after_brackets() {
     let s = "#main[data-behavior = \"1\"] {}";
     let expected = "#main[data-behavior=\"1\"]{}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 
     let s = "#main[data-behavior = \"1\"] .aclass";
     let expected = "#main[data-behavior=\"1\"] .aclass";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 
     let s = "#main[data-behavior = \"1\"] ul.aclass";
     let expected = "#main[data-behavior=\"1\"] ul.aclass";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn check_whitespaces_in_calc() {
     let s = ".foo { width: calc(130px     + 10%); }";
     let expected = ".foo{width:calc(130px + 10%);}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 
     let s = ".foo { width: calc(130px + (45% - 10% +   (12   *   2px))); }";
     let expected = ".foo{width:calc(130px + (45% - 10% + (12 * 2px)));}";
-    assert_eq!(minify(s).expect("minify failed"), expected.to_owned());
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
@@ -265,7 +265,7 @@ fn check_weird_comments() {
     font-weight: 30em;
 }/**/";
     let expected = ".test1{font-weight:30em;}.test2{font-weight:30em;}.test3{font-weight:30em;}";
-    assert_eq!(minify(s).expect("minify failed").as_str(), expected);
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
@@ -274,13 +274,13 @@ fn check_slash_slash() {
     background-image: url(data:image/webp;base64,c//S4KP//ZZ/19Uj/UA==);
 }";
     let expected = "body{background-image:url(data:image/webp;base64,c//S4KP//ZZ/19Uj/UA==);}";
-    assert_eq!(minify(s).expect("minify failed").as_str(), expected);
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
 }
 
 #[test]
 fn issue_80() {
     assert_eq!(
-        minify("@import 'i';t{x: #fff;}").unwrap(),
+        minify("@import 'i';t{x: #fff;}").unwrap().to_string(),
         "@import 'i';t{x:#fff;}",
     );
 }

--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -427,7 +427,7 @@ fn fill_other<'a>(
 }
 
 #[allow(clippy::comparison_chain)]
-pub fn tokenize<'a>(source: &'a str) -> Result<Tokens<'a>, &'static str> {
+pub(super) fn tokenize<'a>(source: &'a str) -> Result<Tokens<'a>, &'static str> {
     let mut v = Vec::with_capacity(1000);
     let mut iterator = source.char_indices().peekable();
     let mut start = 0;
@@ -624,10 +624,19 @@ fn clean_tokens(mut v: Vec<Token<'_>>) -> Vec<Token<'_>> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Tokens<'a>(pub Vec<Token<'a>>);
+pub(super) struct Tokens<'a>(Vec<Token<'a>>);
+
+impl<'a> Tokens<'a> {
+    pub(super) fn write<W: std::io::Write>(self, mut w: W) -> std::io::Result<()> {
+        for token in self.0.iter() {
+            write!(w, "{}", token)?;
+        }
+        Ok(())
+    }
+}
 
 impl<'a> fmt::Display for Tokens<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for token in self.0.iter() {
             write!(f, "{}", token)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,9 @@ fn main() {
             .to_str()
             .unwrap_or("")
         {
-            "css" => call_minifier(arg, |s| css::minify(s).expect("css minification failed")),
+            "css" => call_minifier(arg, |s| {
+                css::minify(s).expect("css minification failed").to_string()
+            }),
             "js" => call_minifier(arg, js::minify),
             "json" => call_minifier(arg, json::minify),
             // "html" | "htm" => call_minifier(arg, html::minify),


### PR DESCRIPTION
Instead, allow the user to pass in a writer and write the tokens
incrementally. Or they can still stringify as before if they want.
