### PR TITLE
perf: apply lto, strip and codegen opts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,13 @@ name = "minifier"
 [[bin]]
 name = "minifier"
 doc = false
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1
+opt-level = 3
+
+[profile.release.package."*"]
+codegen-units = 1
+opt-level = 3


### PR DESCRIPTION
This applies lto, strip and codegen optimizations.

Effects:
 - smaller binaries
 - (mostly) faster binaries
 - longer build times

The overwrides of `opt-level` and `[profile.release.package."*"]` make sure that build scripts are optimized and dependencies are already optimized during dependency compilation 