### PR TITLE
Support escaped characters

### DIFF
--- a/src/css/tests.rs
+++ b/src/css/tests.rs
@@ -285,6 +285,16 @@ fn check_slash_slash() {
 }
 
 #[test]
+fn check_escaped_characters() {
+    let s = r#".before\:prose-headings\:content-\[\'\#\'\] :is(:where(h1,h2,h3,h4,h5,h6,th):not(:where([class~="not-prose"] *)))::before{
+  --en-content: '#';
+  content: var(--en-content);
+}"#;
+    let expected = r#".before\:prose-headings\:content-\[\'\#\'\] :is(:where(h1,h2,h3,h4,h5,h6,th):not(:where([class~="not-prose"] *)))::before{--en-content:'#';content:var(--en-content);}"#;
+    assert_eq!(minify(s).expect("minify failed").to_string(), expected);
+}
+
+#[test]
 fn issue_80() {
     assert_eq!(
         minify("@import 'i';t{x: #fff;}").unwrap().to_string(),

--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -30,6 +30,7 @@ pub enum ReservedChar {
     Tilde,
     Dollar,
     Circumflex,
+    Backslash,
 }
 
 impl fmt::Display for ReservedChar {
@@ -61,6 +62,7 @@ impl fmt::Display for ReservedChar {
                 ReservedChar::Tilde => '~',
                 ReservedChar::Dollar => '$',
                 ReservedChar::Circumflex => '^',
+                ReservedChar::Backslash => '\\',
             }
         )
     }
@@ -94,6 +96,7 @@ impl TryFrom<char> for ReservedChar {
             '~' => Ok(ReservedChar::Tilde),
             '$' => Ok(ReservedChar::Dollar),
             '^' => Ok(ReservedChar::Circumflex),
+            '\\' => Ok(ReservedChar::Backslash),
             _ => Err("Unknown reserved char"),
         }
     }
@@ -465,7 +468,16 @@ pub(super) fn tokenize(source: &str) -> Result<Tokens<'_>, &'static str> {
                 || v.last()
                     .unwrap_or(&Token::Char(ReservedChar::Space))
                     .is_a_media();
+
             match c {
+                ReservedChar::Backslash => {
+                    v.push(Token::Char(ReservedChar::Backslash));
+
+                    if iterator.next().is_some() {
+                        pos += 1;
+                        v.push(Token::Other(&source[pos..pos + 1]));
+                    }
+                }
                 ReservedChar::Quote | ReservedChar::DoubleQuote => {
                     if let Some(s) = get_string(source, &mut iterator, &mut pos, c) {
                         v.push(s);


### PR DESCRIPTION
This PR adds support for escaped characters prefixed by a backslash. However it does not fully implements the spec (https://www.w3.org/TR/CSS21/syndata.html#characters): support for ISO code escaping sequences and backslashes followed by a newline in strings will need to be implemented in a separate PR.

Fixes #110 