### PR TITLE
don't use clap as default feature for lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ license = "MIT"
 edition = "2021"
 
 [features]
+default = ["clap"]
 html = ["regex"]
 
 [dependencies]
-clap = { version = "4.5.13", features = ["cargo"] }
+clap = { version = "4.5.13", features = ["cargo"], optional = true }
 regex = { version = "1.5.5", optional = true }
 
 [lib]
@@ -24,6 +25,7 @@ name = "minifier"
 [[bin]]
 name = "minifier"
 doc = false
+required-features = ["clap"]
 
 [profile.release]
 lto = true

--- a/src/css/mod.rs
+++ b/src/css/mod.rs
@@ -24,13 +24,13 @@ pub fn minify(content: &str) -> Result<Minified<'_>, &'static str> {
 
 pub struct Minified<'a>(token::Tokens<'a>);
 
-impl<'a> Minified<'a> {
+impl Minified<'_> {
     pub fn write<W: io::Write>(self, w: W) -> io::Result<()> {
         self.0.write(w)
     }
 }
 
-impl<'a> fmt::Display for Minified<'a> {
+impl fmt::Display for Minified<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -212,7 +212,7 @@ impl<'a> TryFrom<&'a str> for SelectorElement<'a> {
     }
 }
 
-impl<'a> fmt::Display for SelectorElement<'a> {
+impl fmt::Display for SelectorElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             SelectorElement::Class(c) => write!(f, ".{}", c),
@@ -264,7 +264,7 @@ pub enum Token<'a> {
     Operator(Operator),
 }
 
-impl<'a> fmt::Display for Token<'a> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             // Token::AtRule(at_rule) => write!(f, "{}", at_rule, content),
@@ -281,7 +281,7 @@ impl<'a> fmt::Display for Token<'a> {
     }
 }
 
-impl<'a> Token<'a> {
+impl Token<'_> {
     fn is_comment(&self) -> bool {
         matches!(*self, Token::Comment(_))
     }
@@ -321,7 +321,7 @@ impl<'a> Token<'a> {
     }
 }
 
-impl<'a> PartialEq<ReservedChar> for Token<'a> {
+impl PartialEq<ReservedChar> for Token<'_> {
     fn eq(&self, other: &ReservedChar) -> bool {
         match *self {
             Token::Char(c) => c == *other,
@@ -655,7 +655,7 @@ fn clean_tokens(mut v: Vec<Token<'_>>) -> Vec<Token<'_>> {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(super) struct Tokens<'a>(Vec<Token<'a>>);
 
-impl<'a> Tokens<'a> {
+impl Tokens<'_> {
     pub(super) fn write<W: std::io::Write>(self, mut w: W) -> std::io::Result<()> {
         for token in self.0.iter() {
             write!(w, "{}", token)?;
@@ -664,7 +664,7 @@ impl<'a> Tokens<'a> {
     }
 }
 
-impl<'a> fmt::Display for Tokens<'a> {
+impl fmt::Display for Tokens<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for token in self.0.iter() {
             write!(f, "{}", token)?;

--- a/src/js/token.rs
+++ b/src/js/token.rs
@@ -207,7 +207,7 @@ impl fmt::Display for Keyword {
     }
 }
 
-impl<'a> TryFrom<&'a str> for Keyword {
+impl TryFrom<&str> for Keyword {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Keyword, Self::Error> {
@@ -383,7 +383,7 @@ pub enum Token<'a> {
     FloatingNumber(&'a str),
 }
 
-impl<'a> fmt::Display for Token<'a> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Token::Keyword(x) => write!(f, "{}", x),
@@ -414,7 +414,7 @@ impl<'a> fmt::Display for Token<'a> {
     }
 }
 
-impl<'a> Token<'a> {
+impl Token<'_> {
     pub fn is_comment(&self) -> bool {
         matches!(*self, Token::Comment(_))
     }
@@ -883,7 +883,7 @@ impl<'a> MyPeekable<'a> {
     }
 }
 
-impl<'a> Iterator for MyPeekable<'a> {
+impl Iterator for MyPeekable<'_> {
     type Item = (usize, char);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1035,14 +1035,14 @@ macro_rules! tokens_writer {
     };
 }
 
-impl<'a> Tokens<'a> {
+impl Tokens<'_> {
     pub(super) fn write<W: std::io::Write>(self, mut w: W) -> std::io::Result<()> {
         tokens_writer!(self, w);
         Ok(())
     }
 }
 
-impl<'a> fmt::Display for Tokens<'a> {
+impl fmt::Display for Tokens<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         tokens_writer!(self, f);
         Ok(())

--- a/src/js/tools.rs
+++ b/src/js/tools.rs
@@ -191,13 +191,13 @@ pub fn minify(source: &str) -> Minified<'_> {
 
 pub struct Minified<'a>(token::Tokens<'a>);
 
-impl<'a> Minified<'a> {
+impl Minified<'_> {
     pub fn write<W: io::Write>(self, w: W) -> io::Result<()> {
         self.0.write(w)
     }
 }
 
-impl<'a> fmt::Display for Minified<'a> {
+impl fmt::Display for Minified<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -894,7 +894,7 @@ fn clean_except3() {
 
 #[test]
 fn name_generator() {
-    let s = std::iter::repeat('a').take(36).collect::<String>();
+    let s = "a".repeat(36);
     // We need to generate enough long strings to reach the point that the name generator
     // generates names with 3 characters.
     let s = std::iter::repeat(s)
@@ -913,7 +913,7 @@ fn name_generator() {
         .apply(crate::js::clean_tokens)
         .apply(aggregate_strings)
         .to_string();
-    assert!(result.find(",r_aaa=").is_some());
+    assert!(result.contains(",r_aaa="));
     assert!(result.find(",r_ab=").unwrap() < result.find(",r_ba=").unwrap());
 }
 

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -44,13 +44,13 @@ pub fn minify(json: &str) -> Minified<'_> {
 #[derive(Debug)]
 pub struct Minified<'a>(JsonMultiFilter<'a, JsonMethod>);
 
-impl<'a> Minified<'a> {
+impl Minified<'_> {
     pub fn write<W: io::Write>(self, w: W) -> io::Result<()> {
         self.0.write(w)
     }
 }
 
-impl<'a> fmt::Display for Minified<'a> {
+impl fmt::Display for Minified<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -92,7 +92,7 @@ fn removal_from_read() {
 
 #[test]
 fn removal_of_control_characters() {
-    let input = "\n".into();
+    let input = "\n";
     let expected: String = "".into();
     let actual = minify(input);
     assert_eq!(actual.to_string(), expected);
@@ -106,8 +106,7 @@ fn removal_of_whitespace_outside_of_tags() {
               "test2": "",
               "test3": " "
             }
-        "#
-    .into();
+        "#;
     let expected: String = "{\"test\":\"\\\" test2\",\"test2\":\"\",\"test3\":\" \"}".into();
     let actual = minify(input);
     assert_eq!(actual.to_string(), expected);

--- a/src/json/string.rs
+++ b/src/json/string.rs
@@ -27,7 +27,7 @@ impl<'a, P: Clone> JsonMultiFilter<'a, P> {
     }
 }
 
-impl<'a, P: Clone> fmt::Debug for JsonMultiFilter<'a, P> {
+impl<P: Clone> fmt::Debug for JsonMultiFilter<'_, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Filter")
             .field("minifier", &self.minifier)


### PR DESCRIPTION
Noticed `clap` in rustdoc deps.

Make only bin depend on `clap`, but to make `cargo b --bin minifier` work, i've added `clap` to default features. Anyway, default features can be cleaned in upcoming major releases.