### PR TITLE
Clean up a few error cases where we disagree with cssparser

### DIFF
--- a/src/css/tests.rs
+++ b/src/css/tests.rs
@@ -314,3 +314,10 @@ fn check_unicode_edge_cases() {
         let _ = minify(edge_case);
     }
 }
+
+#[test]
+fn check_weird_input() {
+    assert!(minify(r##""}"##).is_err());
+    assert!(minify(r##"/*}"##).is_err());
+    assert_eq!(minify(".").unwrap().to_string(), ".");
+}

--- a/src/css/tests.rs
+++ b/src/css/tests.rs
@@ -320,4 +320,5 @@ fn check_weird_input() {
     assert!(minify(r##""}"##).is_err());
     assert!(minify(r##"/*}"##).is_err());
     assert_eq!(minify(".").unwrap().to_string(), ".");
+    assert_eq!(minify("//**/*").unwrap().to_string(), "/ *");
 }

--- a/src/css/token.rs
+++ b/src/css/token.rs
@@ -416,13 +416,7 @@ fn fill_other<'a>(
                 v.push(Token::SelectorElement(s));
             } else {
                 let s = &source[start..pos];
-                if !s.starts_with(':')
-                    && !s.starts_with('.')
-                    && !s.starts_with('#')
-                    && !s.starts_with('@')
-                {
-                    v.push(Token::Other(s));
-                }
+                v.push(Token::Other(s));
             }
         } else {
             v.push(Token::Other(&source[start..pos]));
@@ -482,6 +476,8 @@ pub(super) fn tokenize(source: &str) -> Result<Tokens<'_>, &'static str> {
                 ReservedChar::Quote | ReservedChar::DoubleQuote => {
                     if let Some(s) = get_string(source, &mut iterator, &mut pos, c) {
                         v.push(s);
+                    } else {
+                        return Err("Unclosed string");
                     }
                 }
                 ReservedChar::Star
@@ -491,6 +487,8 @@ pub(super) fn tokenize(source: &str) -> Result<Tokens<'_>, &'static str> {
                     v.pop();
                     if let Some(s) = get_comment(source, &mut iterator, &mut pos) {
                         v.push(s);
+                    } else {
+                        return Err("Unclosed comment");
                     }
                 }
                 ReservedChar::OpenBracket => {


### PR DESCRIPTION
In a few cases, minifier-rs might reject a file that cssparser accepts, since [the CSS spec allows it](https://www.w3.org/TR/css-syntax-3/#error-handling):

> When errors occur in CSS, the parser attempts to recover gracefully, throwing away only the minimum amount of content before returning to parsing as normal. This is because errors aren’t always mistakes—new syntax looks like an error to an old parser, and it’s useful to be able to add new syntax to the language without worrying about stylesheets that include it being completely broken in older UAs.

We probably want to support minifying some unrecognized syntax, but unclosed comments and strings are probably safe to reject outright without creating expressiveness gaps.