### PR TITLE
Fix out of bound read on unterminated comments.

### DIFF
--- a/src/js/token.rs
+++ b/src/js/token.rs
@@ -661,6 +661,7 @@ fn get_comment<'a>(
         }
     }
     // Unclosed comment so returning it anyway...
+    current_pos = std::cmp::min(current_pos, source.len() - 1);
     let ret = builder(&source[*start_pos..=current_pos]);
     *start_pos = current_pos + 2;
     ret
@@ -1405,4 +1406,14 @@ fn test_comments() {
             Token::Other("a"),
         ],
     );
+}
+
+#[test]
+fn test_unclosed_comment_at_eof() {
+    // An unterminated `/*` at end of input must not panic on an out-of-bounds
+    // string slice; the comment body simply runs to the end of the source.
+    assert_eq!(&tokenize("/*").0, &[Token::Comment("")]);
+    assert_eq!(&tokenize("a/*").0, &[Token::Other("a"), Token::Comment("")]);
+    assert_eq!(&tokenize("/*x").0, &[Token::Comment("x")]);
+    assert_eq!(&tokenize("/*!").0, &[Token::License("")]);
 }


### PR DESCRIPTION
Hi,

I am on the Cargo Team and was recently hired by the Rust Foundation to help triage AI discovered bugs. This bug was found with AI, namely [scrutineer](https://github.com/alpha-omega-security/scrutineer) and Fable. Except where specifically labeled this report was written by me.

The test was written by Fable. But I wrote the fix by hand. I did not like the fix The AI had come up with.

I looked into the same pattern occurs in the CSS module, but that code seems to handle unterminated quotes completely differently.